### PR TITLE
Instant snapshot

### DIFF
--- a/instantSnapshot.js
+++ b/instantSnapshot.js
@@ -1,0 +1,5 @@
+require('dotenv').config()
+
+const { handleImage } = require('./timelapse')
+
+handleImage()

--- a/timelapse/handleImage.js
+++ b/timelapse/handleImage.js
@@ -13,7 +13,9 @@ const imageDir = path.join(__dirname, '../media/images')
 async function handleImage () {
   getImage()
     .then(pruneOldestImage)
-    .then(renameImages)
+    .then(shouldRename => {
+      if (shouldRename) renameImages
+    })
     // .then(sendLatestImage)
     .catch(log)
 }
@@ -40,7 +42,9 @@ const pruneOldestImage = () => {
         toDelete = path.join(imageDir, files.shift())
         log(`deleting ${toDelete}`)
         fs.unlinkSync(toDelete)
+        return true
       }
+      return false
     })
     .catch(log)
 }
@@ -48,17 +52,12 @@ const pruneOldestImage = () => {
 function renameImages () {
   return fs.readdir(imageDir)
     .then(files => {
-      /**
-       * @todo create standalone reverse `forEach`
-       */
       const filesLen = files.length - 1
-      for (let index = filesLen; index >= 0; index--) {
-        const file = files[index]
-        fs.renameSync(
-          path.join(imageDir, file),
-          path.join(imageDir, `frame_${pad(index + 1, 4)}.png`)
-        )
-      }
+      files.forEach((file, index) => {
+        const oldName = path.join(imageDir, file)
+        const newName = path.join(imageDir, `frame_${pad(index + 1, 4)}.png`)
+        fs.renameSync(oldName, newName)
+      })
     })
     .catch(log)
 }

--- a/timelapse/handleImage.js
+++ b/timelapse/handleImage.js
@@ -28,8 +28,9 @@ function getImage () {
     nopreview: true
   })
 
-  log('grabbing image...')
   return camera.snap()
+    .then((res) => { log(`image captured`) })
+    .catch(log)
 }
 
 const pruneOldestImage = () => {

--- a/utils/log.js
+++ b/utils/log.js
@@ -1,5 +1,5 @@
 function log () { 
-  console.log(`[${new Date()}] ${[...arguments].join(' ')}`)
+  console.log(`${[...arguments].join(' ')}`)
 }
 
 module.exports = log


### PR DESCRIPTION
- Built manual snapshot and timelapse modules for testing. 
- Fixed a bug that caused all files in `media/images` to be deleted when a prune -> batch rename operation occurred.

Batch renaming was starting at the end of a file name array and working backwards to the first file, overwriting each file with the one before it until there was only one file left.

This functionality has been replaced with a simple `forEach` where the file is renamed with the file before its' name. e.g. `frame_0002.png` becomes `frame_0001.png`. On prune the first file is deleted so this operation shouldn't result in any unintended file overwriting. 